### PR TITLE
Add uaac for uaa integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,3 +9,4 @@ RUN apt-get update \
 RUN curl -L "https://s3-us-west-1.amazonaws.com/cf-cli-releases/releases/v${CF_CLI_VERSION}/cf-cli_${CF_CLI_VERSION}_linux_x86-64.tgz" | tar -zx -C /usr/local/bin
 RUN curl -L https://github.com/mikefarah/yq/releases/download/1.14.0/yq_linux_amd64 -o yq && chmod +x yq && mv yq /usr/local/bin/yq
 RUN ln -s /usr/local/bin/yq /usr/local/bin/yaml
+RUN gem install cf-uaac


### PR DESCRIPTION
cf-uaac is the primary tool for connecting to CF UAA in any pipeline, a gem install is all that's required.

## How to test?

```sh
docker build -t paas-tools-ruby
docker run -it paas-tools-ruby /bin/bash
uaac
```