### PR TITLE
Update bundler so we can use the latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,3 +13,4 @@ RUN curl -L "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_
 RUN curl -L "https://github.com/concourse/concourse/releases/download/v${FLY_VERSION}/fly-${FLY_VERSION}-linux-amd64.tgz" | tar -zx -C /usr/local/bin
 RUN ln -s /usr/local/bin/yq /usr/local/bin/yaml
 RUN gem install cf-uaac
+RUN gem install bundler -v 2.0.2


### PR DESCRIPTION
This PR updates bundler to the v2 which is required by some tools. 