### PR TITLE
Bump fly version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.5-stretch
 ENV YQ_VERSION="2.4.0"
 ENV CF_CLI_VERSION="6.45.0"
-ENV FLY_VERSION="5.4.1"
+ENV FLY_VERSION="5.7.0"
 ENV PACKAGES unzip curl openssl ca-certificates git jq musl util-linux gzip bash uuid-runtime coreutils vim tzdata openssh-client gnupg rsync make zip
 RUN apt-get update \
       && apt-get -y upgrade \


### PR DESCRIPTION
This alligns fly version with concourse version that we use.
It will make update-pipelines job to not sync fly version when it runs. 