### PR TITLE
Update fly to v 6.4.0 to match our paas-bootstrap version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 ENV YQ_VERSION="3.2.1"
 ENV CF_CLI_VERSION="7.1.0"
-ENV FLY_VERSION="5.8.1"
+ENV FLY_VERSION="6.4.0"
 ENV BOSH_VERSION="6.2.1"
 ENV PACKAGES "awscli unzip curl openssl ca-certificates git jq musl util-linux gzip bash uuid-runtime coreutils vim tzdata openssh-client gnupg rsync make zip build-essential zlibc zlib1g-dev ruby-dev libxslt-dev libxml2-dev libssl-dev libreadline-dev libyaml-dev libcurl4-openssl-dev"
 RUN apt-get update \


### PR DESCRIPTION
so fly doesn"t have to be downloaded every time in update-pipelines job"